### PR TITLE
optional argument to specify not using network

### DIFF
--- a/adafruit_esp32s2tft/__init__.py
+++ b/adafruit_esp32s2tft/__init__.py
@@ -63,6 +63,9 @@ class ESP32S2TFT(PortalBase):
                      portrait/rotated
     :param scale: Default scale is 1, but can be an integer of 1 or greater
     :param debug: Turn on debug print outs. Defaults to False.
+    :param use_network: Enable network initialization. Defaults to True.
+                        Setting to False will allow you to use the library without a secrets.py
+                        file with wifi configuration in it.
 
     """
 

--- a/adafruit_esp32s2tft/__init__.py
+++ b/adafruit_esp32s2tft/__init__.py
@@ -80,13 +80,17 @@ class ESP32S2TFT(PortalBase):
         rotation: int = 0,
         scale: int = 1,
         debug: bool = False,
+        use_network: bool = True
     ) -> None:
 
-        network = Network(
-            status_neopixel=status_neopixel,
-            extract_values=False,
-            debug=debug,
-        )
+        if use_network:
+            network = Network(
+                status_neopixel=status_neopixel,
+                extract_values=False,
+                debug=debug,
+            )
+        else:
+            network = None
 
         graphics = Graphics(
             default_bg=default_bg,

--- a/examples/esp32s2tft_simpletest.py
+++ b/examples/esp32s2tft_simpletest.py
@@ -7,10 +7,7 @@ import random
 from rainbowio import colorwheel
 from adafruit_esp32s2tft import ESP32S2TFT
 
-esp32s2tft = ESP32S2TFT(
-    default_bg=0xFFFF00,
-    scale=2,
-)
+esp32s2tft = ESP32S2TFT(default_bg=0xFFFF00, scale=2, use_network=False)
 
 # Create the labels
 esp32s2tft.add_text(


### PR DESCRIPTION
This change allows the `secrets.py` file to be optional with a keyword argument that defaults to True (same behavior as current). While helping someone on discord I noticed that the simpletest script crashes if the user doesn't have a valid secrets.py file, but the example itself doesn't make use of the network. 

I think it would be great if people could start playing with the display and other non-network related functionality without having to set up extra things that won't be used yet. 

Also modified the simpletest example to use this new argument so that it can run without a secrets.py file. I tested successfully on a Feather S2 TFT on CircuitPython 7.2.5