### PR TITLE
Fix invalid secret lookup

### DIFF
--- a/adafruit_esp32s2tft/__init__.py
+++ b/adafruit_esp32s2tft/__init__.py
@@ -64,7 +64,7 @@ class ESP32S2TFT(PortalBase):
     :param scale: Default scale is 1, but can be an integer of 1 or greater
     :param debug: Turn on debug print outs. Defaults to False.
     :param use_network: Enable network initialization. Defaults to True.
-                        Setting to False will allow you to use the library without a secrets.py
+                        Setting to False will allow you to use the library without a settings.toml
                         file with wifi configuration in it.
 
     """

--- a/adafruit_esp32s2tft/network.py
+++ b/adafruit_esp32s2tft/network.py
@@ -73,13 +73,12 @@ class Network(NetworkBase):
 
     def init_io_mqtt(self) -> IO_MQTT:
         """Initialize MQTT for Adafruit IO"""
-        try:
-            aio_username = self._secrets["aio_username"]
-            aio_key = self._secrets["aio_key"]
-        except KeyError:
-            raise KeyError(
-                "Adafruit IO secrets are kept in secrets.py, please add them there!\n\n"
-            ) from KeyError
+        aio_username = self._get_setting["ADAFRUIT_AIO_USERNAME"]
+        aio_key = self._get_setting["ADAFRUIT_AIO_KEY"]
+        if None in [aio_username, aio_key]:
+            raise AttributeError(
+                "Adafruit IO keys are kept in settings.toml, please add them there."
+            )
 
         return self.init_mqtt(IO_MQTT_BROKER, 8883, aio_username, aio_key, True)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,6 @@ autodoc_mock_imports = [
     "ssl",
     "wifi",
     "socketpool",
-    "secrets",
     "bitmaptools",
 ]
 


### PR DESCRIPTION
Remove using `self._secrets` which was removed from NetworkBase of PortalBase in [v1.15.0](https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/compare/1.14.9...1.15.0)